### PR TITLE
Kampo Assist：Render デプロイ準備（PostgreSQL 対応）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,20 @@
+ruby "3.2.2"
+
 source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 8.1.1"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
-# Use sqlite3 as the database for Active Record
-gem "sqlite3", ">= 2.1"
+# 開発・テストでは sqlite3 を使う
+group :development, :test do
+  gem "sqlite3", ">= 2.1"
+end
+
+# 本番（Render）では PostgreSQL を使う
+group :production do
+  gem "pg", "~> 1.5"
+end
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,9 @@ GEM
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
+    pg (1.6.2-aarch64-linux)
+    pg (1.6.2-arm64-darwin)
+    pg (1.6.2-x86_64-linux)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -396,6 +399,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  pg (~> 1.5)
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.1)
@@ -411,6 +415,9 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+
+RUBY VERSION
+   ruby 3.2.2p53
 
 BUNDLED WITH
    2.4.10

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,19 +23,7 @@ test:
 
 # Store production database in the storage/ directory, which by default
 # is mounted as a persistent Docker volume in config/deploy.yml.
+# 本番環境は Render の PostgreSQL を利用する
 production:
-  primary:
-    <<: *default
-    database: storage/production.sqlite3
-  cache:
-    <<: *default
-    database: storage/production_cache.sqlite3
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *default
-    database: storage/production_queue.sqlite3
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *default
-    database: storage/production_cable.sqlite3
-    migrations_paths: db/cable_migrate
+  url: <%= ENV["DATABASE_URL"] %>
+  


### PR DESCRIPTION
## 概要
本番デプロイ環境として Render を利用するため、Rails アプリの設定を以下の内容で整備しました。
- PostgreSQL への移行（本番環境用）
- pg gem の追加
- config/database.yml の本番向け修正
- Build / Start コマンドの設定
- config/database.yml の本番環境設定を修正

---

##  変更内容
**Gem の追加・更新**

* PostgreSQL 利用のため、pg を Gemfile に追加

gem 'pg', group: :production

* bundle install を実行し Gemfile.lock を更新
---

 **database.yml の修正**
* 本番環境を PostgreSQL 用に書き換え
* DATABASE_URL （Render が自動で発行）を利用する設定へ変更
```
production:
  url: <%= ENV["DATABASE_URL"] %>
```
* sqlite の本番用設定を削除（Render では使用しないため）
---

**Render 側の設定**
* Web Service の新規作成
* 言語：Ruby を選択
* ブランチ：main を指定
* Build コマンドを修正：

bundle install && bundle exec rake db:migrate

* Start コマンドを修正：

bundle exec puma -C config/puma.rb

---

 **環境変数の設定（Render Dashboard）**
設定した内容：
* DATABASE_URL（Render が自動生成）
* RAILS_ENV=production
* RACK_ENV=production
* SECRET_KEY_BASE（Render の Generate を使用）

---

##  動作確認
* デプロイ途中でエラーが出たため、pg 追加などの修正を完了して本 PR でマージ予定。
* デプロイ再実行で正常動作する見込み。

