### PR TITLE
Kampo関連6テーブル（領域・病名・症状・中間）を追加

### DIFF
--- a/app/models/disease.rb
+++ b/app/models/disease.rb
@@ -1,0 +1,6 @@
+class Disease < ApplicationRecord
+  belongs_to :medical_area
+
+  has_many :kampo_diseases, dependent: :destroy
+  has_many :kampos, through: :kampo_diseases
+end

--- a/app/models/kampo.rb
+++ b/app/models/kampo.rb
@@ -1,0 +1,7 @@
+class Kampo < ApplicationRecord
+  has_many :kampo_diseases, dependent: :destroy
+  has_many :diseases, through: :kampo_diseases
+
+  has_many :kampo_symptoms, dependent: :destroy
+  has_many :symptoms, through: :kampo_symptoms
+end

--- a/app/models/kampo_disease.rb
+++ b/app/models/kampo_disease.rb
@@ -1,0 +1,4 @@
+class KampoDisease < ApplicationRecord
+  belongs_to :kampo
+  belongs_to :disease
+end

--- a/app/models/kampo_symptom.rb
+++ b/app/models/kampo_symptom.rb
@@ -1,0 +1,4 @@
+class KampoSymptom < ApplicationRecord
+  belongs_to :kampo
+  belongs_to :symptom
+end

--- a/app/models/medical_area.rb
+++ b/app/models/medical_area.rb
@@ -1,0 +1,4 @@
+class MedicalArea < ApplicationRecord
+  has_many :diseases, dependent: :destroy
+  has_many :symptoms, dependent: :destroy
+end

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -1,0 +1,6 @@
+class Symptom < ApplicationRecord
+  belongs_to :medical_area
+
+  has_many :kampo_symptoms, dependent: :destroy
+  has_many :kampos, through: :kampo_symptoms
+end

--- a/db/migrate/20251207183532_create_kampos.rb
+++ b/db/migrate/20251207183532_create_kampos.rb
@@ -1,0 +1,12 @@
+class CreateKampos < ActiveRecord::Migration[8.1]
+  def change
+    create_table :kampos do |t|
+      t.string :name,      null: false
+      t.string :kana_name, null: false
+      t.string :note
+      t.string :detail
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251207183548_create_medical_areas.rb
+++ b/db/migrate/20251207183548_create_medical_areas.rb
@@ -1,0 +1,10 @@
+class CreateMedicalAreas < ActiveRecord::Migration[8.1]
+  def change
+    create_table :medical_areas do |t|
+      t.string  :name,          null: false
+      t.integer :display_order, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251207183556_create_diseases.rb
+++ b/db/migrate/20251207183556_create_diseases.rb
@@ -1,0 +1,10 @@
+class CreateDiseases < ActiveRecord::Migration[8.1]
+  def change
+    create_table :diseases do |t|
+      t.references :medical_area, null: false, foreign_key: true
+      t.string :name,             null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251207183603_create_symptoms.rb
+++ b/db/migrate/20251207183603_create_symptoms.rb
@@ -1,0 +1,10 @@
+class CreateSymptoms < ActiveRecord::Migration[8.1]
+  def change
+    create_table :symptoms do |t|
+      t.references :medical_area, null: false, foreign_key: true
+      t.string :name,             null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251207183614_create_kampo_diseases.rb
+++ b/db/migrate/20251207183614_create_kampo_diseases.rb
@@ -1,0 +1,11 @@
+class CreateKampoDiseases < ActiveRecord::Migration[8.1]
+  def change
+    create_table :kampo_diseases do |t|
+      t.references :kampo, null: false, foreign_key: true
+      t.references :disease, null: false, foreign_key: true
+      t.integer :weight,     null: false, default: 1
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251207183623_create_kampo_symptoms.rb
+++ b/db/migrate/20251207183623_create_kampo_symptoms.rb
@@ -1,0 +1,11 @@
+class CreateKampoSymptoms < ActiveRecord::Migration[8.1]
+  def change
+    create_table :kampo_symptoms do |t|
+      t.references :kampo, null: false, foreign_key: true
+      t.references :symptom, null: false, foreign_key: true
+      t.integer :weight
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,72 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2025_12_07_183623) do
+  create_table "diseases", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "medical_area_id", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["medical_area_id"], name: "index_diseases_on_medical_area_id"
+  end
+
+  create_table "kampo_diseases", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "disease_id", null: false
+    t.integer "kampo_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "weight", default: 1, null: false
+    t.index ["disease_id"], name: "index_kampo_diseases_on_disease_id"
+    t.index ["kampo_id"], name: "index_kampo_diseases_on_kampo_id"
+  end
+
+  create_table "kampo_symptoms", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "kampo_id", null: false
+    t.integer "symptom_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "weight"
+    t.index ["kampo_id"], name: "index_kampo_symptoms_on_kampo_id"
+    t.index ["symptom_id"], name: "index_kampo_symptoms_on_symptom_id"
+  end
+
+  create_table "kampos", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "detail"
+    t.string "kana_name", null: false
+    t.string "name", null: false
+    t.string "note"
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "medical_areas", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "display_order", default: 0, null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "symptoms", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "medical_area_id", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["medical_area_id"], name: "index_symptoms_on_medical_area_id"
+  end
+
+  add_foreign_key "diseases", "medical_areas"
+  add_foreign_key "kampo_diseases", "diseases"
+  add_foreign_key "kampo_diseases", "kampos"
+  add_foreign_key "kampo_symptoms", "kampos"
+  add_foreign_key "kampo_symptoms", "symptoms"
+  add_foreign_key "symptoms", "medical_areas"
+end

--- a/spec/models/disease_spec.rb
+++ b/spec/models/disease_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Disease, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/kampo_disease_spec.rb
+++ b/spec/models/kampo_disease_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe KampoDisease, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/kampo_spec.rb
+++ b/spec/models/kampo_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Kampo, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/kampo_symptom_spec.rb
+++ b/spec/models/kampo_symptom_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe KampoSymptom, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/medical_area_spec.rb
+++ b/spec/models/medical_area_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MedicalArea, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/symptom_spec.rb
+++ b/spec/models/symptom_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Symptom, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
漢方候補算出の基盤となるデータモデルを実装しました。
本PRでは、漢方・領域・病名・症状、およびそれらを関連付ける中間テーブルを作成しています。

---

##  変更内容

### ▼ モデル・テーブルの追加
以下のモデルとDBテーブルを生成しました。

- Kampo（漢方マスタ）
  - name, kana_name, note, detail

- MedicalArea（領域マスタ）
  - name, display_order

- Disease（病名マスタ）
  - medical_area:references, name

- Symptom（症状マスタ）
  - medical_area:references, name

- KampoDisease（中間：漢方 × 病名）
  - kampo:references, disease:references, weight

- KampoSymptom（中間：漢方 × 症状）
  - kampo:references, symptom:references, weight

---

### ◆ Rails console にて動作確認済み
- MedicalArea → Disease/Symptom の関連付け
- Kampo → Disease/Symptom の関連付け（中間テーブル経由）
- weight の保存確認
- 各テーブルのデータ挿入・取得が正しく動作することを確認

## 関連 Issue
Close #6 #7 #8 #9 #10 #23 