### PR TITLE
feat: 漢方の詳細ページを追加し結果画面から遷移できるように実装

### DIFF
--- a/app/controllers/kampos_controller.rb
+++ b/app/controllers/kampos_controller.rb
@@ -1,0 +1,5 @@
+class KamposController < ApplicationController
+  def show
+    @kampo = Kampo.find(params[:id])
+  end
+end

--- a/app/views/kampos/show.html.erb
+++ b/app/views/kampos/show.html.erb
@@ -1,0 +1,34 @@
+<div class="kampo-show-container">
+  <h1 class="mb-2"><%= @kampo.name %></h1>
+  <% if @kampo.kana_name.present? %>
+    <p class="text-muted mb-4"><%= @kampo.kana_name %></p>
+  <% end %>
+
+  <section class="mb-4">
+    <h2 class="h5 mb-2">適応・よく使うパターン</h2>
+    <% if @kampo.note.present? %>
+      <p><%= simple_format(@kampo.note) %></p>
+    <% else %>
+      <p class="text-muted">適応に関する情報は未登録です。</p>
+    <% end %>
+  </section>
+
+  <section class="mb-4">
+    <h2 class="h5 mb-2">注意点・禁忌</h2>
+    <% if @kampo.detail.present? %>
+      <p><%= simple_format(@kampo.detail) %></p>
+    <% else %>
+      <p class="text-muted">注意点・禁忌に関する情報は未登録です。</p>
+    <% end %>
+  </section>
+
+  <div class="mt-4">
+    <%= link_to "検索結果に戻る",
+        results_search_path(
+          medical_area_ids: params[:medical_area_ids],
+          disease_ids:      params[:disease_ids],
+          symptom_ids:      params[:symptom_ids]
+        ),
+        class: "btn btn-secondary" %>
+  </div>
+</div>

--- a/app/views/searches/results.html.erb
+++ b/app/views/searches/results.html.erb
@@ -63,9 +63,14 @@
     <% @results.each do |result| %>
       <li class="list-group-item">
         <h3 class="h5 mb-1">
-          <%= result.kampo.name %>
+          <%= link_to result.kampo.name,
+                kampo_path(
+                    result.kampo,
+                    medical_area_ids: params[:medical_area_ids],
+                    disease_ids:      params[:disease_ids],
+                    symptom_ids:      params[:symptom_ids]
+                ) %>
         </h3>
-
         <% if result.kampo.note.present? %>
           <p class="mb-1 text-muted">
             <%= truncate(result.kampo.note, length: 300) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   get "searches/step1"
   get "searches/step2"
   get "/search/results", to: "searches#results", as: :search_results
+  resources :kampos, only: [:show]
   # ====== Health Check ======
   get "up" => "rails/health#show", as: :rails_health_check
 


### PR DESCRIPTION
## 概要
漢方ごとの適応・注意点（note/detail）を確認できる詳細ページを新規追加しました。
検索結果画面から各漢方の詳細へ遷移し、文章量の多い情報も見やすく整理された構造で表示します。

## 主な変更点
- `resources :kampos, only: [:show]` を追加し、漢方の詳細ページへのルーティングを定義
- `KamposController` を新規作成し、`show` アクションで対象の漢方データを取得
- `app/views/kampos/show.html.erb` を作成
  - name / kana_name / note / detail をセクションごとに分けて表示
- 検索結果画面の漢方名を `kampo_path` へのリンクに変更
- 詳細ページから結果画面へ戻れるよう、検索条件（領域・病名・症状）をクエリパラメータとして引き継ぐ処理を追加

## 動作確認
- Step1 → Step2 → Results → 詳細 の一連の遷移が正常に動作することを確認
- note / detail が適切に整形されて表示されることを確認
- 「検索結果に戻る」リンクから、元と同じ条件の results 画面に戻れることを確認

## 関連 Issue
Close #57  
Close #58  
Close #59  

## 今後のタスクリスト
- 残りの seed データ投入を完了させる
- UI／UX 改善向けの Issue を再整理し、フェーズ2に向けて計画化する
- TOPページの作成（検索導線の追加・説明文・利用ガイド等）

