### PR TITLE
Step1/Step2 の領域選択を auto-submit 化し、検索操作を改善

### DIFF
--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -1,0 +1,10 @@
+// app/javascript/controllers/auto_submit_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+// data-controller="auto-submit" が付いた要素（ここでは form）に対するコントローラ
+export default class extends Controller {
+  submit() {
+    // このコントローラが紐づいている要素（= form）を送信
+    this.element.requestSubmit()
+  }
+}

--- a/app/views/searches/step1.html.erb
+++ b/app/views/searches/step1.html.erb
@@ -1,61 +1,67 @@
 <div class="search-step1-container">
     <h1>漢方検索 ステップ1：領域と病名の選択</h1>
 
-    <%= form_with url: step1_search_path, method: :get, local: true do %>
     <div class="search-step1-layout">
-        <!-- 左：領域一覧（複数選択可） -->
+
         <div class="search-step1-areas">
-            <h2 class="h5 mb-3">領域を選択（複数可）</h2>
+            <%= form_with url: step1_search_path,
+                    method: :get,
+                    local: true,
+                    html: { data: { controller: "auto-submit" } } do %>
+                <div class="search-step1-layout">
+                    <!-- 左：領域一覧（複数選択可） -->
+                    <div class="search-step1-areas">
+                        <h2 class="h5 mb-3">領域を選択（複数可）</h2>
 
-            <% selected_ids = Array(params[:medical_area_ids]) %>
+                        <% selected_ids = Array(params[:medical_area_ids]) %>
 
-            <% @medical_areas.each do |area| %>
-                <div class="form-check mb-1">
-                <%= check_box_tag "medical_area_ids[]",
-                                    area.id,
-                                    selected_ids.include?(area.id.to_s),
-                                    id: "medical_area_#{area.id}",
-                                    class: "form-check-input" %>
-                <%= label_tag "medical_area_#{area.id}",
-                                area.name,
-                                class: "form-check-label" %>
+                        <% @medical_areas.each do |area| %>
+                            <div class="form-check mb-1">
+                                <%= check_box_tag "medical_area_ids[]",
+                                                    area.id,
+                                                    selected_ids.include?(area.id.to_s),
+                                                    id: "medical_area_#{area.id}",
+                                                    class: "form-check-input",
+                                                    data: { action: "change->auto-submit#submit" } %>
+                                <%= label_tag "medical_area_#{area.id}",
+                                                area.name,
+                                                class: "form-check-label" %>
+                            </div>
+                        <% end %>
+
+                    </div>
                 </div>
             <% end %>
-            <div class="mt-3">
-                <%= submit_tag "病名一覧を更新", class: "btn btn-secondary" %>
-            </div>
         </div>
-    <% end %>
-
-    <hr>
-
-    <% if @diseases.present? %>
-    <%= form_with url: step2_search_path, method: :get, local: true do %>
-        <% Array(params[:medical_area_ids]).each do |area_id| %>
-        <%= hidden_field_tag "medical_area_ids[]", area_id %>
-        <% end %>
 
         <div class="search-step1-diseases">
-        <h2 class="h5 mb-3">病名を選択してください（複数可）</h2>
+            <% if @diseases.present? %>
+                <%= form_with url: step2_search_path, method: :get, local: true do %>
+                    <% Array(params[:medical_area_ids]).each do |area_id| %>
+                        <%= hidden_field_tag "medical_area_ids[]", area_id %>
+                    <% end %>
 
-        <div class="d-flex flex-wrap gap-3">
-            <% @diseases.each do |disease| %>
-            <div class="form-check me-3 mb-2">
-                <%= check_box_tag "disease_ids[]",
-                                disease.id,
-                                Array(params[:disease_ids]).include?(disease.id.to_s),
-                                id: "disease_#{disease.id}",
-                                class: "form-check-input" %>
-                <%= label_tag "disease_#{disease.id}",
-                            disease.name,
-                            class: "form-check-label" %>
-            </div>
+                    <h2 class="h5 mb-3">病名を選択してください（複数可）</h2>
+
+                    <div class="d-flex flex-wrap gap-3">
+                        <% @diseases.each do |disease| %>
+                            <div class="form-check me-3 mb-2">
+                                <%= check_box_tag "disease_ids[]",
+                                            disease.id,
+                                            Array(params[:disease_ids]).include?(disease.id.to_s),
+                                            id: "disease_#{disease.id}",
+                                            class: "form-check-input" %>
+                                <%= label_tag "disease_#{disease.id}",
+                                            disease.name,
+                                            class: "form-check-label" %>
+                            </div>
+                        <% end %>
+                    </div>
+                
+                    <%= submit_tag "症状を選ぶ（ステップ2へ）",
+                                class: "btn btn-primary" %>
+                <% end %>
             <% end %>
         </div>
-        </div>
-
-        <%= submit_tag "症状を選ぶ（ステップ2へ）",
-                    class: "btn btn-primary" %>
-    <% end %>
-    <% end %>
+    </div>
 </div>

--- a/app/views/searches/step2.html.erb
+++ b/app/views/searches/step2.html.erb
@@ -15,7 +15,11 @@
   <div class="search-step2-layout">
     <!-- 左：領域（複数選択可） -->
     <div class="search-step2-areas">
-      <%= form_with url: step2_search_path, method: :get, local: true do %>
+      <%# ★ ここに Stimulus コントローラを付与 %>
+      <%= form_with url: step2_search_path,
+                    method: :get,
+                    local: true,
+                    html: { data: { controller: "auto-submit" } } do %>
         <% @disease_ids.each do |id| %>
           <%= hidden_field_tag "disease_ids[]", id %>
         <% end %>
@@ -30,16 +34,13 @@
                               area.id,
                               selected_area_ids.include?(area.id.to_s),
                               id: "symptom_area_#{area.id}",
-                              class: "form-check-input" %>
+                              class: "form-check-input",
+                              data: { action: "change->auto-submit#submit" } %>
             <%= label_tag "symptom_area_#{area.id}",
                           area.name,
                           class: "form-check-label" %>
           </div>
         <% end %>
-
-        <div class="mt-3">
-          <%= submit_tag "症状一覧を更新", class: "btn btn-secondary" %>
-        </div>
       <% end %>
     </div>
 
@@ -55,7 +56,7 @@
             <%= hidden_field_tag "disease_ids[]", id %>
           <% end %>
 
-          <p class="mb-2">症状を選択してください（複数可）</p>
+          <h2 class="h5 mb-3">症状を選択してください（複数可）</h2>
 
           <% @symptoms.each do |symptom| %>
             <div class="form-check mb-1">
@@ -81,7 +82,8 @@
         <% end %>
       <% else %>
         <p class="text-muted">
-          左の領域を選択して「症状一覧を更新」を押してください。
+          左の領域を選択すると自動で症状一覧が更新されます。
+          <%# ↑ 文言も「更新ボタン」じゃなく自動更新寄りに変えておくと親切 %>
         </p>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要
漢方検索フロー（Step1 / Step2）において、領域チェック時に毎回「更新」ボタンを押す必要があり UX が低下していたため、Stimulus を用いて **領域変更時にフォームを自動送信（auto submit）** するよう改善しました。

これにより、ユーザーはチェックした瞬間に病名・症状リストが更新されるため、
検索体験が大幅に向上します。

---

## 変更内容

### Step1
- 領域フォーム（左カラム）に `data-controller="auto-submit"` を付与
- 領域チェックボックスに `data-action="change->auto-submit#submit"` を追加  
  → チェック時に自動で step1 に GET され、病名リストが更新される
- `.search-step1-layout` を左右カラムで横並びになるよう HTML 構造を修正

### ✔ Step2
- 領域フォーム（左カラム）に auto-submit を導入  
  → 領域変更時に症状リストが自動更新される

### ✔ Stimulus controller
`app/javascript/controllers/auto_submit_controller.js` を新規作成し、
`this.element.requestSubmit()` により自動送信を実装。

---

## 動作確認
- Step1 で領域チェックを変更すると、自動で病名一覧が更新されること
- Step1 で病名を選択し「症状を選ぶ」を押すと Step2 に遷移すること
- Step2 で領域チェックを変更すると、自動で症状一覧が更新されること
- Step2 から検索結果画面へ正常に遷移できること
- レイアウト（左右横並び）が従来通り表示されること
- 既存の検索ロジック・結果表示に影響がないこと

---

## 変更ファイル
- `app/views/searches/step1.html.erb`
- `app/views/searches/step2.html.erb`
- `app/javascript/controllers/auto_submit_controller.js`
- （必要に応じて）CSS の調整

---

## 補足
- 今後は Turbo Frame を使うと、ページ全体のリロードなしで部分更新も検討できます
