### PR TITLE
TOPページ追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,21 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+.top-hero {
+  background: linear-gradient(135deg, #ffffff 0%, #f5fbff 60%, #e3f2fd 100%);
+}
+
+.top-hero .text-primary {
+  color: #0d6efd !important; /* Bootstrapのprimaryブルー */
+}
+
+.top-hero-card {
+  border-radius: 0.75rem;
+}
+
+/* モバイルで少し余白ゆったりめに */
+@media (max-width: 767.98px) {
+  .top-hero {
+    padding-top: 1.5rem;
+  }
+}

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,84 @@
-<h1>Kampo Assist MVP</h1>
-<p>漢方処方アシストツールです。</p>
+<div class="top-hero bg-light">
+  <div class="container py-5">
+    <div class="row align-items-center">
+      <!-- 左：キャッチコピー -->
+      <div class="col-md-7 mb-4 mb-md-0">
+        <h1 class="mb-3 text-primary fw-bold">
+          漢方処方アシストツール
+        </h1>
+        <p class="lead mb-4 text-muted">
+          症状・病名から、適応する漢方薬の候補を素早く絞り込むための<br>
+          医療従事者向けサポートアプリです。
+        </p>
+
+        <%= link_to "漢方検索を始める",
+                    step1_search_path,
+                    class: "btn btn-primary btn-lg px-4 me-2" %>
+      </div>
+
+      <!-- 右：イメージカード -->
+      <div class="col-md-5">
+        <div class="card shadow-sm border-0 top-hero-card">
+          <div class="card-body">
+            <h2 class="h5 text-primary mb-3">検索フロー（3ステップ）</h2>
+            <ol class="mb-3 text-muted small">
+              <li>領域・病名を選択（Step1）</li>
+              <li>症状を選択（Step2）</li>
+              <li>スコア付きで漢方候補を一覧表示</li>
+            </ol>
+            <p class="mb-0 text-muted small">
+              選択した病名・症状ごとにスコアリングを行い、<br>
+              候補となる漢方を優先度順に表示します。
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<hr class="my-5">
+
+<div id="about-app" class="container mb-5">
+  <div class="text-center mb-4">
+    <h2 class="h4 text-primary mb-2">このアプリでできること</h2>
+    <p class="text-muted">
+      漢方の選択に悩む場面で、候補出し・学習の両面をサポートします。
+    </p>
+  </div>
+
+  <div class="row g-4">
+    <div class="col-md-4">
+      <div class="card h-100 shadow-sm border-0">
+        <div class="card-body">
+          <h3 class="h6 text-primary mb-2">症状・病名からの絞り込み</h3>
+          <p class="small text-muted mb-0">
+            領域・病名・症状を選択することで、複数の観点から漢方候補をスコアリングし、優先度の高い順に表示します。
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-4">
+      <div class="card h-100 shadow-sm border-0">
+        <div class="card-body">
+          <h3 class="h6 text-primary mb-2">スコアの見える化</h3>
+          <p class="small text-muted mb-0">
+            病名スコア・症状スコアを別々に表示し、どの観点で候補に挙がっているかを一目で確認できます。
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-4">
+      <div class="card h-100 shadow-sm border-0">
+        <div class="card-body">
+          <h3 class="h6 text-primary mb-2">漢方の詳細情報(未実装部分)</h3>
+          <p class="small text-muted mb-0">
+            各漢方の注意点やメモ（note / detail）を確認でき、処方検討や自己学習にも活用できます。
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
アプリのトップページ（`home#index`）がほぼ未実装の状態だったため、
医療系サービスらしい白×ブルー基調のトップページを追加し、
漢方検索フロー（Step1）への導線を整備しました。

## 変更内容

### 1. トップページの実装
- `home#index` にトップページを実装
  - アプリ名・キャッチコピーの表示
  - 「漢方検索を始める」ボタンを配置（`step1_search_path` への導線）

### 2. アプリ概要セクションの追加
- トップページ下部に「このアプリでできること」を3カラムで表示
  - 症状・病名からの絞り込み
  - スコアの見える化
  - 各漢方の詳細情報の確認

### 3. スタイルの追加（医療系の白×ブルー）
- `top-hero` コンテナに白〜淡いブルーのグラデーション背景を適用
- カードとレイアウトに軽めの余白・シャドウを追加

## 変更ファイル（例）
- `app/views/home/index.html.erb`
- `app/assets/stylesheets/...` （トップページ用のスタイルを追加したファイル名）

## 動作確認
- [x] 「漢方検索を始める」ボタンから Step1（領域・病名選択画面）に遷移できること

