### PR TITLE
Feature/disease symptom grid layout

### DIFF
--- a/app/assets/stylesheets/searches.css
+++ b/app/assets/stylesheets/searches.css
@@ -45,18 +45,56 @@
 }
 
 /* 病名・症状のチェックボックスをグリッド（1行20個）で表示 */
+/* 病名・症状のチェックボックスをタイル状に表示 */
+/* 病名・症状リストを「縦に並べて、下まで行ったら次の列」にする */
+/* 20項目で1列に収めるレイアウト */
+/* 1列20行で縦に並べて、21個目から次の列へ */
 .disease-list,
 .symptom-list {
   display: grid;
-  grid-template-columns: repeat(20, minmax(0, 1fr));
-  column-gap: 0.75rem; /* 横の間隔 */
-  row-gap: 0.25rem;    /* 縦の間隔 */
+  grid-auto-flow: column;               /* 縦に埋めてから次の列へ */
+  grid-template-rows: repeat(20, auto); /* 1列あたり最大20個 */
+  column-gap: 2rem;
+  row-gap: 0.25rem;
 }
 
-/* スマホのときは列数を減らす（見やすさ優先） */
+/* □ とテキストを横にピタッと並べる */
+.disease-label,
+.symptom-label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+/* ブラウザのデフォルト余白を消す */
+.disease-checkbox,
+.symptom-checkbox {
+  margin: 0;
+}
+
+/* スマホでは1列にする */
 @media (max-width: 768px) {
   .disease-list,
   .symptom-list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    column-count: 1;
   }
+}
+
+.btn-area {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.btn-nav {
+  padding: 0.5rem 1.2rem;     /* ボタンの大きさ */
+  border-radius: 6px;         /* 角丸 */
+  font-weight: 600;
+  text-decoration: none;      /* リンク下線を消す */
+  display: inline-block;      /* ブロック化して押しやすい */
+}
+
+.btn-nav:hover {
+  opacity: 0.85;              /* ホバー時 */
 }

--- a/app/views/searches/results.html.erb
+++ b/app/views/searches/results.html.erb
@@ -3,13 +3,15 @@
   <% back_to_step1_params = params.permit(medical_area_ids: [], disease_ids: []) %>
   <% back_to_step2_params = params.permit(medical_area_ids: [], disease_ids: [], symptom_ids: []) %>
 
-  <%= link_to "Step1に戻る",
-              step1_search_path(back_to_step1_params),
-              class: "btn btn-outline-secondary" %>
+  <div class="btn-area">
+    <%= link_to "Step1に戻る",
+                step1_search_path(back_to_step1_params),
+                class: "btn btn-outline-secondary btn-nav" %>
 
-  <%= link_to "Step2に戻る",
-              step2_search_path(back_to_step2_params),
-              class: "btn btn-secondary" %>
+    <%= link_to "Step2に戻る",
+                step2_search_path(back_to_step2_params),
+                class: "btn btn-secondary btn-nav" %>
+  </div>
 </div>
 <!-- 条件の確認表示 -->
 <div class="mb-3">

--- a/app/views/searches/step1.html.erb
+++ b/app/views/searches/step1.html.erb
@@ -43,17 +43,17 @@
 
                     <h2 class="h5 mb-3">病名を選択してください（複数可）</h2>
 
-                    <div class="d-flex flex-wrap gap-3">
+                    <div class="disease-list">
                         <% @diseases.each do |disease| %>
-                            <div class="form-check me-3 mb-2">
-                                <%= check_box_tag "disease_ids[]",
-                                            disease.id,
-                                            Array(params[:disease_ids]).include?(disease.id.to_s),
-                                            id: "disease_#{disease.id}",
-                                            class: "form-check-input" %>
-                                <%= label_tag "disease_#{disease.id}",
-                                            disease.name,
-                                            class: "form-check-label" %>
+                            <div class="disease-item">
+                                <label class="disease-label">
+                                    <%= check_box_tag "disease_ids[]",
+                                                    disease.id,
+                                                    Array(params[:disease_ids]).include?(disease.id.to_s),
+                                                    id: "disease_#{disease.id}",
+                                                    class: "disease-checkbox" %>
+                                    <span><%= disease.name %></span>
+                                </label>
                             </div>
                         <% end %>
                     </div>

--- a/app/views/searches/step2.html.erb
+++ b/app/views/searches/step2.html.erb
@@ -3,13 +3,11 @@
 
   <!-- 選択された病名の確認用 -->
   <div class="mb-3">
-    <p>選択された病名:</p>
-    <ul>
-      <% @diseases.each do |disease| %>
-        <li><%= disease.name %></li>
-      <% end %>
-    </ul>
-  </div>
+  <p>
+    選択された病名：
+    <%= @diseases.map(&:name).join(" / ") %>
+  </p>
+</div>
 
   <!-- ① 領域フォーム と ② 症状フォーム を横並びに配置 -->
   <div class="search-step2-layout">
@@ -58,18 +56,20 @@
 
           <h2 class="h5 mb-3">症状を選択してください（複数可）</h2>
 
-          <% @symptoms.each do |symptom| %>
-            <div class="form-check mb-1">
-              <%= check_box_tag "symptom_ids[]",
-                                symptom.id,
-                                Array(params[:symptom_ids]).include?(symptom.id.to_s),
-                                id: "symptom_#{symptom.id}",
-                                class: "form-check-input" %>
-              <%= label_tag "symptom_#{symptom.id}",
-                            symptom.name,
-                            class: "form-check-label" %>
-            </div>
-          <% end %>
+          <div class="symptom-list">
+            <% @symptoms.each do |symptom| %>
+              <div class="symptom-item">
+                <label class="symptom-label">
+                  <%= check_box_tag "symptom_ids[]",
+                                    symptom.id,
+                                    Array(params[:symptom_ids]).include?(symptom.id.to_s),
+                                    id: "symptom_#{symptom.id}",
+                                    class: "symptom-checkbox" %>
+                  <span><%= symptom.name %></span>
+                </label>
+              </div>
+            <% end %>
+          </div>
 
           <div class="mt-3 d-flex gap-2">
             <%= link_to "戻る",


### PR DESCRIPTION
## 概要
Step1・Step2 の検索 UI を大幅に改善し、
チェックボックスの視認性と操作性を向上しました。
特に、病名・症状が大量に表示されるケースでも使いやすいよう、
1 列 20 件で自動改行する縦基準レイアウト（20-row grid） を導入しました。

また、戻るボタンの UI もボタン化し、操作に迷わない導線を追加しています。

## 変更内容

### 1. 病名・症状チェックボックス UI の刷新
* Bootstrap の form-check を廃止し、独自クラスで安定した表示へ変更
* チェックボックス + ラベルを横並びで密着表示
* 1 列 20 行で自動的に次の列へ移動するグリッドレイアウトを採用

### 2. HTML 構造の整理
* .disease-list / .symptom-list をループの外へ移動し、「1件ごとに grid が切れる」問題を解消
* チェック項目は .disease-item / .symptom-item に統一

### 3. 戻るボタンの UX 改善

### 4. 小さな改善
* 選択された病名の表示を
「胃炎 / 扁桃腺炎 / 〜」の横並びテキスト形式 に変更しコンパクト化

## 動作確認
* Step1 → Step2 → 結果 の遷移が正常に動作
* チェックボックスが 20 件ごとに正しく改行される
  ※かなり多くなると、バグるけど絶対そこまで選択することはないが今後余裕あれば改善予定
* 戻るボタンが正常に動作する
* 選択状態が保持される

