### PR TITLE
Enable force_ssl in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }


### PR DESCRIPTION
## 概要
本番環境において HTTPS を強制するため、`config.force_ssl = true` を有効化しました。
これにより、http アクセス時は自動的に https へリダイレクトされ、安全な通信のみを許可します。

## 変更内容
- production 環境で `config.force_ssl = true` を有効化
- http → https の自動リダイレクトを有効化

## 動作確認
- http://kampo-assist-1.onrender.com にアクセスすると  
  https://kampo-assist-1.onrender.com へ自動リダイレクトされることを確認
- HTTPS 接続時にブラウザの警告が表示されないことを確認

## 目的・背景
本リリースに向けたセキュリティ対策の一環として、通信の暗号化を必須とするために対応しました。
SNS シェア（OGP）や独自ドメイン設定を見据えた基盤整備でもあります。

## 影響範囲
- production 環境のみ
- development / test 環境への影響なし

## 関連 Issue
Close #101 