### PR TITLE
OGPとTwitter Cardを動的対応で追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <% site_name = "漢方アシスト" %> # 訂正済
+    <% site_name = "漢方アシスト" %>
     <% page_title = content_for?(:title) ? "#{yield(:title)} | #{site_name}" : site_name %>
     <% page_desc  = content_for?(:description) ? yield(:description) : "症状・病名から適応する漢方薬候補をスコアリングして提示する支援ツールです。" %>
     <% page_url   = request.original_url %>
@@ -21,14 +21,16 @@
     <meta property="og:title" content="<%= page_title %>">
     <meta property="og:description" content="<%= page_desc %>">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="<%= page_url %>">
-    <meta property="og:image" content="<%= ogp_image %>">
+    <meta property="og:url" content="<%= request.original_url %>">
+    <meta property="og:image" content="https://kampo-assist-1.onrender.com/ogp.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="<%= page_title %>">
     <meta name="twitter:description" content="<%= page_desc %>">
-    <meta name="twitter:image" content="<%= ogp_image %>">
+    <meta name="twitter:image" content="https://kampo-assist-1.onrender.com/ogp.png">
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
## 概要
SNSでURLをシェアした際に、タイトル・説明文・画像が適切に表示されるよう、
OGP（Open Graph Protocol）および Twitter Card の設定を追加しました。

共通レイアウトにデフォルトのOGP設定を持たせつつ、
ページごとに title / description を切り替え可能な「動的OGP方針」を採用しています。

※ 独自ドメイン反映前のため、現時点では onrender.com のURLで動作確認しています。

## 主な変更点
- application layout に OGP / Twitter Card の meta タグを追加
- `content_for` を利用し、ページごとに title / description を切り替え可能に対応
- OGP画像（`public/ogp.png`）を作成・設定
- `og:url` を `request.original_url` とし、各ページURLが正しく認識されるよう対応

## OGP方針について
OGPは共通レイアウトでデフォルト値を持たせつつ、
必要に応じて各ページで上書きできる「動的OGP方針」を採用しています。

