### PR TITLE
使い方ページを追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,7 @@
 class StaticPagesController < ApplicationController
-  # skip_before_action :require_login, only: %i[terms privacy]
+  # skip_before_action :require_login, only: %i[terms privacy how_to]
 
   def terms; end
   def privacy; end
+  def how_to; end
 end

--- a/app/views/static_pages/how_to.html.erb
+++ b/app/views/static_pages/how_to.html.erb
@@ -1,0 +1,34 @@
+<div class="container py-5">
+  <h1 class="mb-4">使い方</h1>
+
+  <section class="mb-5">
+    <h2 class="h4 mb-3">漢方アシストとは</h2>
+    <p class="text-muted">
+      漢方アシストは、症状や病名から適応する漢方薬の候補を絞り込む
+      医療従事者向けサポートツールです。<br>
+      複数の観点（病名・症状）をもとにスコアリングし、優先度の高い順に表示します。
+    </p>
+  </section>
+
+  <section class="mb-5">
+    <h2 class="h4 mb-3">検索の流れ（3ステップ）</h2>
+    <ol class="text-muted">
+      <li class="mb-2">領域・病名を選択（Step1）</li>
+      <li class="mb-2">症状を選択（Step2）</li>
+      <li class="mb-2">結果を確認（スコア付きで候補表示）</li>
+    </ol>
+  </section>
+
+  <section class="mb-5">
+    <h2 class="h4 mb-3">注意事項</h2>
+    <p class="text-muted mb-0">
+      ※ 本アプリは診断や処方を行うものではありません。<br>
+      ※ 実際の処方判断は、必ず専門的な知見に基づいて行ってください。
+    </p>
+  </section>
+
+  <div class="mt-4">
+    <%= link_to "漢方検索を始める", step1_search_path, class: "btn btn-primary" %>
+    <%= link_to "トップへ戻る", root_path, class: "btn btn-outline-secondary ms-2" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,4 @@
 Rails.application.routes.draw do
-  get "searches/step1"
-  get "searches/step2"
-  get "/search/results", to: "searches#results", as: :search_results
-  resources :kampos, only: [ :show ]
   # ====== Health Check ======
   get "up" => "rails/health#show", as: :rails_health_check
 
@@ -13,6 +9,7 @@ Rails.application.routes.draw do
   # ====== Static Pages (Legal) ======
   get "terms",   to: "static_pages#terms"
   get "privacy", to: "static_pages#privacy"
+  get "/how_to",  to: "static_pages#how_to",  as: :how_to
 
   # ====== Search Flow ======
   resource :search, only: [] do
@@ -20,4 +17,6 @@ Rails.application.routes.draw do
     get :step2
     get :results
   end
+
+  resources :kampos, only: [ :show ]
 end


### PR DESCRIPTION
## 概要
初めて利用するユーザーが本アプリの目的や操作手順を
迷わず理解できるよう、「使い方」ページを新たに作成しました。

検索の流れ（Step1〜Step3）を簡潔にまとめることで、
漢方アシストの利用イメージを明確にしています。

## 主な変更点
- 使い方ページ（`/how_to`）を新規作成
- 漢方アシストの概要および検索フロー（3ステップ）を明示
- 未ログイン状態でも閲覧可能な静的ページとして実装
- 重複していた検索ルートを整理し、`resource :search` に統一

## 動作確認
- `/how_to` にアクセスし、使い方ページが表示されることを確認
- 「漢方検索を始める」リンクから Step1 に遷移できることを確認
- 既存の検索フローに影響がないことを確認

## 関連 Issue
Close #110 