### PR TITLE
使い方ページへの導線をフッターに追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,6 +51,7 @@
 
     <footer>
       <nav>
+        <%= link_to "使い方", how_to_path %> |
         <%= link_to "利用規約", terms_path %> |
         <%= link_to "プライバシーポリシー", privacy_path %>
       </nav>


### PR DESCRIPTION
## 概要
初めて利用するユーザーが操作方法を確認しやすいよう、
全ページ共通で表示されるフッターに「使い方」ページへの導線を追加しました。

これにより、未ログイン状態でもアプリの利用方法を
迷わず確認できるようになっています。

## 主な変更点
- フッターに「使い方」ページへのリンクを追加
- 既存の利用規約・プライバシーポリシー導線と並べて配置し、
  全ページからアクセス可能に対応

## 動作確認
- 各ページのフッターに「使い方」リンクが表示されることを確認
- リンクをクリックすると `/how_to` ページへ遷移できることを確認

## 関連 Issue
Close #111 