### PR TITLE
Rubocopの基本設定を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,11 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 3.3
+  Exclude:
+    - "db/schema.rb"
+    - "bin/**"
+    - "node_modules/**"
+    - "vendor/**"


### PR DESCRIPTION
## 概要
Rubocop を導入し、Rails Omakase をベースとした基本設定を追加しました。

## 変更内容
- `.rubocop.yml` を追加
- Rails Omakase スタイルを継承
- 不要ファイル（schema.rb / bin / vendor など）を除外

## 補足
- 本PRでは警告の修正は行っていません
- 警告解消は次PR（#127）で対応予定です

## 関連 Issue
Close #126
Close #127 