### PR TITLE
【#145】【OAuth】Googleログインボタンを追加

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -21,3 +21,9 @@
     <%= submit_tag "ログイン" %>
   </div>
 <% end %>
+
+<hr>
+
+<%= form_with url: "/auth/google_oauth2", method: :post, data: { turbo: false } do %>
+  <%= submit_tag "Googleでログイン", class: "btn btn-outline-dark w-100 mt-3" %>
+<% end %>


### PR DESCRIPTION
## 概要
Google OAuthログインを開始するためのログインボタンを追加しました。

## 変更内容
- ログイン画面（user_sessions/new）に「Googleでログイン」ボタンを追加
- OmniAuth の認証開始エンドポイント（POST /auth/google_oauth2）に遷移するよう実装
- Turbo の影響を避けるため、Googleログイン用フォームは turbo 無効化

## 動作確認
- ログイン画面に Googleログインボタンが表示されることを確認
- ボタン押下時に Google の認証画面へ遷移することを確認

## 関連Issue
Close #145  
