### PR TITLE
お気に入り登録・解除のエンドポイントを実装

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,21 @@
+class FavoritesController < ApplicationController
+  before_action :require_login
+  before_action :set_kampo
+
+  def create
+    current_user.favorites.create!(kampo: @kampo)
+    redirect_back fallback_location: kampo_path(@kampo), notice: "お気に入りに追加しました"
+  end
+
+  def destroy
+    favorite = current_user.favorites.find_by!(kampo: @kampo)
+    favorite.destroy!
+    redirect_back fallback_location: kampo_path(@kampo), notice: "お気に入りを解除しました"
+  end
+
+  private
+
+  def set_kampo
+    @kampo = Kampo.find(params[:kampo_id])
+  end
+end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,11 @@ Rails.application.routes.draw do
     get :results
   end
 
-  resources :kampos, only: [ :show ]
+  # ====== Kampos ======
+  resources :kampos, only: [ :show ] do
+    # ====== Favorite ======
+    resource :favorite, only: [ :create, :destroy ]
+  end
   # ====== Auth ======
   resources :users, only: %i[new create]
   resource :user_session, only: %i[new create destroy]

--- a/spec/helpers/favorites_helper_spec.rb
+++ b/spec/helpers/favorites_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the FavoritesHelper. For example:
+#
+# describe FavoritesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe FavoritesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Favorites", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 概要
漢方に対するお気に入り登録・解除のためのエンドポイントを追加しました。
UI実装に先立ち、ルーティングおよびコントローラで基本的なCRUD処理が動作する状態を整えています。

## 主な変更点
- FavoritesController を新規作成
- お気に入り登録（create）・解除（destroy）を実装
- 漢方に紐づく単数リソースとして favorite を定義
- ログインユーザーのみ操作可能とするため require_login を追加

## 動作確認
- `bin/rails routes | grep favorite` でルーティングを確認
- ログイン状態で POST / DELETE が正常に処理されることを確認

## 関連Issue
Close 