### PR TITLE
漢方詳細ページにお気に入り登録/解除ボタンを追加

### DIFF
--- a/app/controllers/kampos_controller.rb
+++ b/app/controllers/kampos_controller.rb
@@ -1,5 +1,6 @@
 class KamposController < ApplicationController
   def show
     @kampo = Kampo.find(params[:id])
+    @favorited = logged_in? && current_user.favorites.exists?(kampo_id: @kampo.id)
   end
 end

--- a/app/views/kampos/show.html.erb
+++ b/app/views/kampos/show.html.erb
@@ -4,6 +4,25 @@
     <p class="text-muted mb-4"><%= @kampo.kana_name %></p>
   <% end %>
 
+  <%# ===== Favorite button ===== %>
+  <% if logged_in? %>
+    <div class="mb-4">
+      <% if @favorited %>
+        <%= button_to "お気に入り解除",
+                      kampo_favorite_path(@kampo),
+                      method: :delete,
+                      class: "btn btn-outline-secondary" %>
+      <% else %>
+        <%= button_to "お気に入りする",
+                      kampo_favorite_path(@kampo),
+                      method: :post,
+                      class: "btn btn-primary" %>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="text-muted mb-4">お気に入りするにはログインが必要です。</p>
+  <% end %>
+
   <section class="mb-4">
     <h2 class="h5 mb-2">適応・よく使うパターン</h2>
     <% if @kampo.note.present? %>


### PR DESCRIPTION
## 概要
漢方詳細ページにお気に入り登録/解除ボタンを追加しました。
ログインユーザーについて、お気に入り済みかどうかで表示を切り替えます（ページリロードで反映）。

## 主な変更点
- 漢方詳細ページに「お気に入りする/解除」ボタンを追加
- ログインユーザーの favorite 状態を判定し、ボタン表示を出し分け

## 動作確認
- 未ログイン時：お気に入り操作ができない表示になること
- ログイン時：登録/解除ができ、詳細ページに戻るとボタン表示が切り替わること

## 関連Issue
Close #152  