### PR TITLE
お気に入り登録/解除のUXを改善

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -3,14 +3,38 @@ class FavoritesController < ApplicationController
   before_action :set_kampo
 
   def create
-    current_user.favorites.create!(kampo: @kampo)
-    redirect_back fallback_location: kampo_path(@kampo), notice: "お気に入りに追加しました"
+    begin
+      current_user.favorites.create!(kampo: @kampo)
+    rescue ActiveRecord::RecordNotUnique
+      # 連打や競合が起きても落とさない（すでに登録済みならOK扱い）
+    end
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          "favorite_kampo_#{@kampo.id}",
+          partial: "kampos/favorite_button",
+          locals: { kampo: @kampo, favorited: true }
+        )
+      end
+      format.html { redirect_back fallback_location: kampo_path(@kampo), notice: "お気に入りに追加しました" }
+    end
   end
 
   def destroy
-    favorite = current_user.favorites.find_by!(kampo: @kampo)
-    favorite.destroy!
-    redirect_back fallback_location: kampo_path(@kampo), notice: "お気に入りを解除しました"
+    favorite = current_user.favorites.find_by(kampo: @kampo)
+    favorite&.destroy
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          "favorite_kampo_#{@kampo.id}",
+          partial: "kampos/favorite_button",
+          locals: { kampo: @kampo, favorited: false }
+        )
+      end
+      format.html { redirect_back fallback_location: kampo_path(@kampo), notice: "お気に入りを解除しました" }
+    end
   end
 
   private

--- a/app/javascript/controllers/submit_disable_controller.js
+++ b/app/javascript/controllers/submit_disable_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  disable() {
+    // form内のsubmitボタンを全部disable
+    const buttons = this.element.querySelectorAll('input[type="submit"], button[type="submit"]')
+    buttons.forEach((btn) => { btn.disabled = true })
+  }
+}

--- a/app/views/kampos/_favorite_button.html.erb
+++ b/app/views/kampos/_favorite_button.html.erb
@@ -1,0 +1,19 @@
+<% if logged_in? %>
+  <% if favorited %>
+    <%= button_to "お気に入り解除",
+                  kampo_favorite_path(kampo),
+                  method: :delete,
+                  class: "btn btn-outline-secondary",
+                  form: { data: { controller: "submit-disable",
+                                  action: "turbo:submit-start->submit-disable#disable" } } %>
+  <% else %>
+    <%= button_to "お気に入りする",
+                  kampo_favorite_path(kampo),
+                  method: :post,
+                  class: "btn btn-primary",
+                  form: { data: { controller: "submit-disable",
+                                  action: "turbo:submit-start->submit-disable#disable" } } %>
+  <% end %>
+<% else %>
+  <p class="text-muted mb-4">お気に入りするにはログインが必要です。</p>
+<% end %>

--- a/app/views/kampos/show.html.erb
+++ b/app/views/kampos/show.html.erb
@@ -5,22 +5,8 @@
   <% end %>
 
   <%# ===== Favorite button ===== %>
-  <% if logged_in? %>
-    <div class="mb-4">
-      <% if @favorited %>
-        <%= button_to "お気に入り解除",
-                      kampo_favorite_path(@kampo),
-                      method: :delete,
-                      class: "btn btn-outline-secondary" %>
-      <% else %>
-        <%= button_to "お気に入りする",
-                      kampo_favorite_path(@kampo),
-                      method: :post,
-                      class: "btn btn-primary" %>
-      <% end %>
-    </div>
-  <% else %>
-    <p class="text-muted mb-4">お気に入りするにはログインが必要です。</p>
+  <%= turbo_frame_tag "favorite_kampo_#{@kampo.id}" do %>
+    <%= render "favorite_button", kampo: @kampo, favorited: @favorited %>
   <% end %>
 
   <section class="mb-4">


### PR DESCRIPTION
## 概要
お気に入り登録/解除のUXを改善しました。Turbo Stream によりボタン部分のみを差し替え、ページ遷移なしで「お気に入りする/解除」が切り替わります。
また、二重送信を防ぐため送信開始時にボタンを無効化し、競合時の unique 制約エラーでも 500 にならないようにしています。

## 主な変更点
- お気に入りボタン領域を Turbo Frame 化し、Turbo Stream（replace）で部分更新
- ボタン表示を partial（`kampos/_favorite_button`）に切り出し
- 送信開始時に submit ボタンを disabled にする Stimulus コントローラを追加（連打対策）
- DBの unique 制約競合（`ActiveRecord::RecordNotUnique`）をハンドリングして例外で落ちないように調整

## 動作確認
- 漢方詳細でお気に入り登録/解除がページ遷移なしに切り替わること
- 連打しても二重送信されない（送信開始時にボタンが無効化される）こと
- 競合が発生してもエラー画面にならず、状態が整合すること

## 関連Issue
Close #153 
Close #154 