### PR TITLE
漢方お気に入り一覧ページを追加

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,10 @@
 class FavoritesController < ApplicationController
   before_action :require_login
-  before_action :set_kampo
+  before_action :set_kampo, only: [ :create, :destroy ]
+
+  def index
+    @kampos = current_user.favorite_kampos.order(:id)
+  end
 
   def create
     begin

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,29 @@
+<div class="container py-3">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="h4 mb-0">お気に入り一覧</h1>
+  </div>
+
+  <% if @kampos.any? %>
+    <ul class="list-group">
+      <% @kampos.each do |kampo| %>
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+          <div>
+            <%= link_to kampo.name, kampo_path(kampo), class: "text-decoration-none" %>
+            <% if kampo.kana_name.present? %>
+              <small class="text-muted ms-2"><%= kampo.kana_name %></small>
+            <% end %>
+          </div>
+
+          <%= button_to "解除",
+                        kampo_favorite_path(kampo),
+                        method: :delete,
+                        class: "btn btn-sm btn-outline-secondary",
+                        form: { data: { controller: "submit-disable",
+                                        action: "turbo:submit-start->submit-disable#disable" } } %>
+        </li>
+      <% end %>
+    </ul>
+  <% else %>
+    <p class="text-muted">お気に入りはまだありません。</p>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,6 +51,7 @@
       <nav>
         <% if current_user %>
           <span>ログイン中</span> |
+          <%= link_to "お気に入り", favorites_path %> |
           <%= button_to "ログアウト", user_session_path, method: :delete %>
         <% else %>
           <%= link_to "ログイン", new_user_session_path %> |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
     # ====== Favorite ======
     resource :favorite, only: [ :create, :destroy ]
   end
+
+  resources :favorites, only: [ :index ]
+
   # ====== Auth ======
   resources :users, only: %i[new create]
   resource :user_session, only: %i[new create destroy]


### PR DESCRIPTION
## 概要
お気に入り一覧ページを追加しました。ログインユーザーの「お気に入り漢方」を /favorites で確認できます。
一覧から漢方詳細へ遷移でき、解除ボタンからお気に入り解除も可能です。

## 主な変更点
- /favorites（FavoritesController#index）を追加
- ログインユーザーの favorite_kampos を一覧表示
- 一覧からお気に入り解除できる導線を追加

## 動作確認
- ログイン状態で /favorites にアクセスできること
- お気に入りがある場合に一覧表示されること
- 解除ボタンでお気に入り解除できること
- お気に入りがない場合に空表示のメッセージが出ること

## 関連Issue
Close #155 