### PR TITLE
お気に入り機能のrequest specを追加

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { "MyString" }
+    sequence(:email) { |n| "user#{n}@example.com" }
     password { "password" }
     password_confirmation { "password" }
   end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,7 +1,92 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Favorites", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  let(:user)  { create(:user, password: "password", password_confirmation: "password") }
+  let(:kampo) { create(:kampo) }
+
+  def login_as(user)
+    post user_session_path, params: { email: user.email, password: "password" }
+  end
+
+  describe "GET /favorites" do
+    context "when not logged in" do
+      it "redirects to login" do
+        get favorites_path
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "when logged in" do
+      it "returns http success" do
+        login_as(user)
+        get favorites_path
+        expect(response).to have_http_status(:success)
+      end
+
+      it "shows favorited kampo" do
+        login_as(user)
+        user.favorites.create!(kampo: kampo)
+
+        get favorites_path
+        expect(response.body).to include(kampo.name)
+      end
+    end
+  end
+
+  describe "POST /kampos/:kampo_id/favorite" do
+    context "when not logged in" do
+      it "does not create favorite and redirects" do
+        expect {
+          post kampo_favorite_path(kampo)
+        }.not_to change(Favorite, :count)
+
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "when logged in" do
+      it "creates favorite" do
+        login_as(user)
+
+        expect {
+          post kampo_favorite_path(kampo)
+        }.to change(Favorite, :count).by(1)
+
+        expect(response).to have_http_status(:found)
+      end
+
+      it "does not raise error when posting twice" do
+        login_as(user)
+
+        post kampo_favorite_path(kampo)
+        expect { post kampo_favorite_path(kampo) }.not_to raise_error
+      end
+    end
+  end
+
+  describe "DELETE /kampos/:kampo_id/favorite" do
+    context "when logged in" do
+      it "destroys favorite" do
+        login_as(user)
+        user.favorites.create!(kampo: kampo)
+
+        expect {
+          delete kampo_favorite_path(kampo)
+        }.to change(Favorite, :count).by(-1)
+
+        expect(response).to have_http_status(:found)
+      end
+
+      it "does not destroy other user's favorite" do
+        other_user = create(:user, password: "password", password_confirmation: "password")
+        other_user.favorites.create!(kampo: kampo)
+
+        login_as(user)
+
+        expect {
+          delete kampo_favorite_path(kampo)
+        }.not_to change(Favorite, :count)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
お気に入り機能（Favorite）の CRUD が正しく動作することを保証するため、request spec を追加しました。
ログイン有無による挙動、登録・解除、他ユーザーのデータを操作できないことを中心にテストしています。

## テスト内容
- GET /favorites
  - 未ログイン時はリダイレクトされること
  - ログイン時に一覧が表示されること
  - お気に入りした漢方が表示されること
- POST /kampos/:kampo_id/favorite
  - 未ログイン時は登録されないこと
  - ログイン時にお気に入り登録できること
  - 連続POSTしても例外が発生しないこと
- DELETE /kampos/:kampo_id/favorite
  - ログイン時にお気に入り解除できること
  - 他ユーザーのお気に入りを解除できないこと

## 補足
- request spec を採用し、HTTPレベルでの挙動を確認しています
- Favorite Epic の最終工程として、機能の安全性を担保する目的のPRです

## 関連Issue
Close #156