### PR TITLE
SearchSessionモデルとDBテーブルを追加

### DIFF
--- a/app/models/search_session.rb
+++ b/app/models/search_session.rb
@@ -1,0 +1,36 @@
+class SearchSession < ApplicationRecord
+  belongs_to :user
+
+  validates :conditions, presence: true
+  validates :conditions_hash, presence: true
+
+  before_validation :normalize_conditions!
+  before_validation :set_conditions_hash!
+
+  private
+
+  def normalize_conditions!
+    self.conditions ||= {}
+
+    normalized = conditions.to_h.deep_dup
+
+    # 配列になり得るキーは、型を整えて昇順ソート（順序揺れ対策）
+    %w[medical_area_ids disease_ids symptom_ids].each do |key|
+      next unless normalized.key?(key)
+
+      normalized[key] = Array(normalized[key])
+                          .reject(&:blank?)
+                          .map(&:to_s)
+                          .sort
+    end
+
+    # 将来増える条件のために、全体のキー順も揃える
+    self.conditions = normalized.sort.to_h
+  end
+
+  def set_conditions_hash!
+    # conditions が空でもpresenceで弾かれる想定だが、念のため
+    payload = conditions.to_h
+    self.conditions_hash = Digest::SHA256.hexdigest(payload.to_json)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :authorizations, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :favorite_kampos, through: :favorites, source: :kampo
+  has_many :search_sessions, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
 

--- a/db/migrate/20260107020655_create_search_sessions.rb
+++ b/db/migrate/20260107020655_create_search_sessions.rb
@@ -1,0 +1,13 @@
+class CreateSearchSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :search_sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.json :conditions, null: false
+      t.string :conditions_hash, null: false
+
+      t.timestamps
+    end
+
+    add_index :search_sessions, [ :user_id, :conditions_hash ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_04_025831) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_07_020655) do
   create_table "authorizations", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email"
@@ -77,6 +77,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_04_025831) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "search_sessions", force: :cascade do |t|
+    t.json "conditions", null: false
+    t.string "conditions_hash", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id", "conditions_hash"], name: "index_search_sessions_on_user_id_and_conditions_hash", unique: true
+    t.index ["user_id"], name: "index_search_sessions_on_user_id"
+  end
+
   create_table "symptoms", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "medical_area_id", null: false
@@ -102,5 +112,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_04_025831) do
   add_foreign_key "kampo_diseases", "kampos"
   add_foreign_key "kampo_symptoms", "kampos"
   add_foreign_key "kampo_symptoms", "symptoms"
+  add_foreign_key "search_sessions", "users"
   add_foreign_key "symptoms", "medical_areas"
 end

--- a/spec/factories/search_sessions.rb
+++ b/spec/factories/search_sessions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :search_session do
+    user { nil }
+    conditions { "" }
+    conditions_hash { "MyString" }
+  end
+end

--- a/spec/models/search_session_spec.rb
+++ b/spec/models/search_session_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SearchSession, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
検索履歴（SearchSession）機能の土台として、SearchSessionモデルとDBテーブルを追加しました。

## 対応内容
- SearchSessionモデル / migration を追加
- conditions(JSON) と conditions_hash を保持
- user_id と conditions_hash のユニーク制約を追加（同一条件集約の土台）
- conditions の正規化（配列の順序揺れ対策）を実装

## 補足
履歴の保存タイミングや画面実装は次PR（#160以降）で対応します。

## 関連Issue
Close #159 