### PR TITLE
検索履歴一覧ページ（SearchSessions#index）を作成

### DIFF
--- a/app/controllers/search_sessions_controller.rb
+++ b/app/controllers/search_sessions_controller.rb
@@ -1,0 +1,7 @@
+class SearchSessionsController < ApplicationController
+  before_action :require_login
+
+  def index
+    @search_sessions = current_user.search_sessions.order(created_at: :desc)
+  end
+end

--- a/app/models/search_session.rb
+++ b/app/models/search_session.rb
@@ -23,6 +23,44 @@ class SearchSession < ApplicationRecord
     Digest::SHA256.hexdigest(normalized.to_json)
   end
 
+  def result_kampo_names(limit: 3)
+    disease_ids = Array(conditions["disease_ids"]).reject(&:blank?)
+    symptom_ids = Array(conditions["symptom_ids"]).reject(&:blank?)
+
+    return [] if disease_ids.blank? && symptom_ids.blank?
+
+    results = KampoSearch.new(disease_ids: disease_ids, symptom_ids: symptom_ids).call
+    results.first(limit).map { |r| r.kampo.name }
+  end
+
+  def result_count
+    disease_ids = Array(conditions["disease_ids"]).reject(&:blank?)
+    symptom_ids = Array(conditions["symptom_ids"]).reject(&:blank?)
+
+    return 0 if disease_ids.blank? && symptom_ids.blank?
+
+    KampoSearch.new(disease_ids: disease_ids, symptom_ids: symptom_ids).call.size
+  end
+
+   # 追加：表示用メソッド（一覧向け）
+  def medical_area_names(limit: 3)
+    ids = Array(conditions["medical_area_ids"]).reject(&:blank?)
+    return [] if ids.blank?
+    MedicalArea.where(id: ids).limit(limit).pluck(:name)
+  end
+
+  def disease_names(limit: 3)
+    ids = Array(conditions["disease_ids"]).reject(&:blank?)
+    return [] if ids.blank?
+    Disease.where(id: ids).limit(limit).pluck(:name)
+  end
+
+  def symptom_names(limit: 3)
+    ids = Array(conditions["symptom_ids"]).reject(&:blank?)
+    return [] if ids.blank?
+    Symptom.where(id: ids).limit(limit).pluck(:name)
+  end
+
   private
 
   def normalize_conditions!

--- a/app/views/search_sessions/index.html.erb
+++ b/app/views/search_sessions/index.html.erb
@@ -1,0 +1,46 @@
+<h1>検索履歴</h1>
+
+<% if @search_sessions.blank? %>
+  <div class="alert alert-info">
+    検索履歴はまだありません。
+  </div>
+<% else %>
+  <ul class="list-group">
+    <% @search_sessions.each do |ss| %>
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <div>
+            <div class="mt-1">
+                <strong>ヒット件数:</strong> <%= ss.result_count %>件
+            </div>
+
+            <% names = ss.result_kampo_names(limit: 3) %>
+            <% if names.present? %>
+                <div class="mt-1">
+                    <strong>漢方例:</strong> <%= names.join(" / ") %>
+                </div>
+            <% end %>
+
+            <div class="mt-1 text-muted small">
+                <div class="mt-1">
+                    <strong>領域：</strong>
+                    <%= ss.medical_area_names.join(" / ").presence || "なし" %>
+                </div>
+
+                <div class="mt-1">
+                    <strong>病名：</strong>
+                    <%= ss.disease_names.join(" / ").presence || "なし" %>
+                </div>
+
+                <div class="mt-1">
+                    <strong>症状：</strong>
+                    <%= ss.symptom_names.join(" / ").presence || "なし" %>
+                </div>
+            </div>
+        </div>
+        <div>
+          <%= link_to "詳細へ", search_session_path(ss), class: "btn btn-sm btn-outline-primary" %>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create]
   resource :user_session, only: %i[new create destroy]
 
+  # ====== Search History ======
+  resources :search_sessions, only: %i[index show]
+
   # ====== Auth (OAuth / OmniAuth) ======
   get "/auth/:provider/callback", to: "oauths#create"
   get "/auth/failure",            to: "oauths#failure"


### PR DESCRIPTION
## 概要
検索履歴（SearchSession）の一覧ページ（index）を追加しました。

## 対応内容
- `/search_sessions`（SearchSessionsController#index）を追加
- current_user の検索履歴を created_at 降順で一覧表示
- conditions に含まれる ID を領域/病名/症状の名称に変換して表示（一覧向けに最大3件まで）
- 各履歴に「詳細へ」リンクを表示（詳細ページは次PRで対応予定）

## 動作確認
- ログイン状態で `/search_sessions` にアクセスすると一覧が表示される
- 未ログイン状態で `/search_sessions` にアクセスするとログインへリダイレクトされる

## 補足
- ページネーションは必要に応じて後続PRで対応します

## 関連Issue
Close #162 