### PR TITLE
検索履歴から同条件で再検索できる導線を追加

### DIFF
--- a/app/views/search_sessions/show.html.erb
+++ b/app/views/search_sessions/show.html.erb
@@ -2,6 +2,9 @@
 
 <div class="mb-3">
   <%= link_to "一覧へ戻る", search_sessions_path, class: "btn btn-outline-secondary" %>
+  <%= link_to "この条件で再検索",
+              results_search_path(@search_session.conditions),
+              class: "btn btn-primary" %>
 </div>
 
 <div class="card">


### PR DESCRIPTION
## 概要
検索履歴詳細ページから、保存された検索条件で検索結果（results）へ遷移できる導線を追加しました。

## 対応内容
- SearchSession#conditions をクエリとして利用し、results_search_path に遷移する「この条件で再検索」ボタンを追加
- step1/step2 を経由せず results へ直接遷移する仕様としました（安定性を優先）

## 動作確認
- 履歴詳細ページから再検索ボタン押下で results に遷移できる
- 遷移先で条件表示と検索結果が保存内容と一致する

## 関連Issue
Close #164 