### PR TITLE
STEP1から全身症候と血液の領域を削除し、最適化

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,7 +3,7 @@ class SearchesController < ApplicationController
 
   def step1
     @medical_areas = MedicalArea
-                   .where.not(name: ["全身症候", "血液"])
+                   .where.not(name: [ "全身症候", "血液" ])
                    .order(:id)
 
     # 複数領域に対応（"-", nil 対策で Array() + reject）


### PR DESCRIPTION
## 🎯 目的
漢方アシストの検索ステップ1において、「全身症候」「血液」領域は選択した場合に多くの漢方がヒットしてしまい、検索結果の絞り込みに寄与しにくい状態でした。  
検索ノイズを減らし、症状・傷病による絞り込みをより有効にするため、これらの領域を検索UIから除外します。

---

## 🔧 変更内容
- Step1（MedicalArea選択）のチェックボックス一覧から  
  **「全身症候」「血液」** を非表示に変更
- DB・seed・漢方と領域の紐付けデータは保持したまま、**表示のみを制御**
- 既存の検索ロジック、SearchSession（検索履
