### PR TITLE
step2への導線を最適化

### DIFF
--- a/app/views/searches/step1.html.erb
+++ b/app/views/searches/step1.html.erb
@@ -64,4 +64,5 @@
             <% end %>
         </div>
     </div>
+    <%= link_to "病名を選ばず次へ", step2_search_path, class: "btn btn-outline-secondary" %>
 </div>


### PR DESCRIPTION
## 🎯 目的
漢方アシストの検索フローにおいて、Step1（領域選択）を必須としていたため、  
「まず病名や症状から探したい」ユーザーが先に進めない状態でした。

領域を選択しなくても検索を開始できるようにすることで、  
ユーザーの思考フローに合わせた柔軟な検索体験を提供します。

---

## 🔧 変更内容
- Step1 に **「領域を選ばず次へ」** ボタンを追加し、未選択でも Step2 へ遷移可能に変更
- Step2 にて、medical_area が未選択の場合は **全ての病名を表示** するように変更
- 既存の「領域 → 病名 → 症状」の検索フローも引き続き利用可能

---

## 🧠 設計意図
実際の診療現場では  
「症状や病名から考える」ケースも多く、必ずしも領域から始まるとは限りません。

検索フローを固定化せず、
- 領域から入る
- 病名から入る

どちらのアプローチも許容することで、  
医療従事者の思考プロセスに沿った検索体験を実現しています。

---

## 🧪 動作確認
- Step1 で何も選択せずに「領域を選ばず次へ」を押すと Step2 に遷移することを確認
- Step2 で全病名が表示され、選択 → Step3 → 検索結果まで正常に遷移することを確認
- 領域を選択した場合も、従来どおり Step2 が領域で絞り込まれて表示されることを確認
