### PR TITLE
step2の全身症候を一番上に固定

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -29,7 +29,10 @@ class SearchesController < ApplicationController
     @disease_ids      = Array(params[:disease_ids]).reject(&:blank?)
 
     # 左カラム：領域一覧（全部表示してOK）
-    @medical_areas = MedicalArea.all.order(:id)
+    @medical_areas = MedicalArea.order(
+      Arel.sql("CASE WHEN name = '全身症候' THEN 0 ELSE 1 END"),
+      :id
+    )
 
     # 右カラム：症状一覧（選択された領域だけ絞る）
     if @medical_area_ids.present?


### PR DESCRIPTION
## 🎯 目的
Step1 では「全身症候」「血液」を検索ノイズ軽減のため非表示にしている一方で、  
Step2（症状選択画面）では領域一覧を参照用として表示しており、  
その中で **「全身症候」が見つけにくい位置に表示されている** 状態でした。

参照性と操作性を高めるため、Step2 の領域一覧において  
「全身症候」を常に先頭に表示するように改善します。

---

## 🔧 変更内容
- Step2 の左カラム（領域一覧）の並び順を変更
  - 「全身症候」を最優先で先頭に表示
  - それ以外の領域は従来どおり id 順で表示
- DBのデータ構造やIDは変更せず、表示順のみを制御

---

##  設計意図
「全身症候」は複数の症状が関与するケースで参照されることが多く、  
Step2 では症状を選ぶ際の補助的なナビゲーションとして  
すぐ目に入る位置にある方がユーザー体験に適しています。

Step1では検索ノイズ削減のため非表示としつつ、  
Step2では参照性を重視して先頭に配置することで、  
検索精度と操作性の両立を図っています。

---

##  動作確認
- Step2 の左カラムで「全身症候」が常に一番上に表示されることを確認
- 他の領域が id 順で表示されていることを確認
- 領域の選択・症状の更新・検索結果への遷移が従来どおり動作することを確認
