### PR TITLE
Adjust medical area display in Step2 (prioritize general, hide blood)

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -3,7 +3,7 @@ class SearchesController < ApplicationController
 
   def step1
     @medical_areas = MedicalArea
-                   .where.not(name: [ "全身症候", "血液" ])
+                   .where.not(name: [ "全身症候" ])
                    .order(:id)
 
     # 複数領域に対応（"-", nil 対策で Array() + reject）
@@ -29,10 +29,12 @@ class SearchesController < ApplicationController
     @disease_ids      = Array(params[:disease_ids]).reject(&:blank?)
 
     # 左カラム：領域一覧（全部表示してOK）
-    @medical_areas = MedicalArea.order(
-      Arel.sql("CASE WHEN name = '全身症候' THEN 0 ELSE 1 END"),
-      :id
-    )
+    @medical_areas = MedicalArea
+      .where.not(name: [ "血液" ])
+      .order(
+        Arel.sql("CASE WHEN name = '全身症候' THEN 0 ELSE 1 END"),
+        :id
+      )
 
     # 右カラム：症状一覧（選択された領域だけ絞る）
     if @medical_area_ids.present?

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,31 @@
+# lib/tasks/data_migrations.rake
+namespace :data_migrations do
+  desc "Move Symptom '貧血' to Disease '貧血'"
+  task move_anemia: :environment do
+    symptom_name = "貧血"
+    disease_name = "貧血"
+
+    anemia_symptom = Symptom.find_by!(name: symptom_name)
+
+    anemia_disease = Disease.find_or_create_by!(
+      name: disease_name,
+      medical_area_id: anemia_symptom.medical_area_id
+    )
+
+    kampo_scope = Kampo.joins(:symptoms).where(symptoms: { id: anemia_symptom.id }).distinct
+    puts "Found #{kampo_scope.count} kampo with Symptom '#{symptom_name}'."
+
+    updated = 0
+    ActiveRecord::Base.transaction do
+      kampo_scope.find_each(batch_size: 200) do |kampo|
+        next if kampo.diseases.exists?(anemia_disease.id)
+
+        kampo.diseases << anemia_disease
+        updated += 1
+      end
+    end
+
+    puts "Attached Disease '#{disease_name}' to #{updated} kampo."
+    puts "Done."
+  end
+end


### PR DESCRIPTION
##  目的
漢方アシストの検索精度とドメインの整合性を高めるため、  
血液領域の「貧血」を **症状（Symptom）から病名（Disease）へ移行** しました。

あわせて、検索ステップ2（症状選択画面）における領域表示を最適化し、  
ユーザーがより直感的に症状を選択できるUIに改善しています。

---

##  変更内容

### ① 「貧血」を症状 → 病名に移行
- Disease に「貧血」を追加
- これまで Symptom「貧血」に紐づいていた漢方（9件）を  
  Disease「貧血」にも紐づけ直し
- Step2 の症状一覧から「貧血」を非表示にし、  
  病名としてのみ選択されるように変更

### ② Step2 の領域表示を最適化
- 「全身症候」を常に先頭に表示
- 「血液」を Step2 では非表示に変更（検索ノイズ削減）

```ruby
@medical_areas = MedicalArea
  .where.not(name: ["血液"])
  .order(
    Arel.sql("CASE WHEN name = '全身症候' THEN 0 ELSE 1 END"),
    :id
  )
