### PR TITLE
【CaseNote】CaseNoteモデルを作成

### DIFF
--- a/app/models/case_note.rb
+++ b/app/models/case_note.rb
@@ -1,0 +1,3 @@
+class CaseNote < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_kampos, through: :favorites, source: :kampo
   has_many :search_sessions, dependent: :destroy
+  has_many :case_notes, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true
 

--- a/db/migrate/20260112142659_create_case_notes.rb
+++ b/db/migrate/20260112142659_create_case_notes.rb
@@ -1,0 +1,9 @@
+class CreateCaseNotes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :case_notes do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_07_020655) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_12_142659) do
   create_table "authorizations", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email"
@@ -21,6 +21,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_07_020655) do
     t.integer "user_id", null: false
     t.index ["provider", "uid"], name: "index_authorizations_on_provider_and_uid", unique: true
     t.index ["user_id"], name: "index_authorizations_on_user_id"
+  end
+
+  create_table "case_notes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["user_id"], name: "index_case_notes_on_user_id"
   end
 
   create_table "diseases", force: :cascade do |t|
@@ -105,6 +112,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_07_020655) do
   end
 
   add_foreign_key "authorizations", "users"
+  add_foreign_key "case_notes", "users"
   add_foreign_key "diseases", "medical_areas"
   add_foreign_key "favorites", "kampos"
   add_foreign_key "favorites", "users"

--- a/spec/factories/case_notes.rb
+++ b/spec/factories/case_notes.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :case_note do
+    user { nil }
+  end
+end

--- a/spec/models/case_note_spec.rb
+++ b/spec/models/case_note_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CaseNote, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
症例メモ機能の土台として CaseNote モデルとテーブルを追加しました。

## 対応内容
- CaseNote model / migration を追加
- CaseNote belongs_to :user / User has_many :case_notes を追加
- case_notes.user_id に index が作成される構成

## 動作確認
- bin/rails db:migrate が成功すること
- CaseNote のテーブルが作成されること

## 関連Issue
Close #167 