### PR TITLE
CaseNoteにカラム追加。

### DIFF
--- a/app/models/case_note.rb
+++ b/app/models/case_note.rb
@@ -1,3 +1,5 @@
 class CaseNote < ApplicationRecord
   belongs_to :user
+
+  validates :body, presence: true, length: { maximum: 1000 }
 end

--- a/db/migrate/20260112145352_add_body_to_case_notes.rb
+++ b/db/migrate/20260112145352_add_body_to_case_notes.rb
@@ -1,0 +1,5 @@
+class AddBodyToCaseNotes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :case_notes, :body, :text, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_12_142659) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_12_145352) do
   create_table "authorizations", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email"
@@ -24,6 +24,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_12_142659) do
   end
 
   create_table "case_notes", force: :cascade do |t|
+    t.text "body", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false


### PR DESCRIPTION
## 概要
症例メモ機能（CaseNote）の土台として、CaseNote モデル・テーブルを追加しました。
ユーザーに紐づくメモを保持できるようにし、メモ本文を保存するための body カラムも追加しています。

## 対応内容
- CaseNote モデル / case_notes テーブルを追加
- case_notes.user_id を追加し、belongs_to :user / has_many :case_notes の関連を定義
- 症例メモ本文を保存するため case_notes.body（text）を追加
- user_id に index が作成される構成（t.references）

## 動作確認
- bin/rails db:migrate が成功すること
- Case_notes テーブルに user_id / body / timestamps が作成されること
