### PR TITLE
【CaseNote】バリデーションを追加

### DIFF
--- a/app/models/case_note.rb
+++ b/app/models/case_note.rb
@@ -1,3 +1,5 @@
 class CaseNote < ApplicationRecord
   belongs_to :user
+
+  validates :body, presence: true, length: { maximum: 1000 }
 end


### PR DESCRIPTION
## 概要
CaseNote のデータ制約を定義するため、body の必須/最大文字数バリデーションを追加

## 対応内容
- validates :body, presence: true, length: { maximum: 1000 } を追加

## 動作確認
- body: "" で "Body can't be blank" が出ること
- 1000文字超で "Body is too long (maximum is 1000 characters)" が出ること

## 関連Issue
Close #168 