### PR TITLE
【CaseNote】メモ作成画面を作成 #170

### DIFF
--- a/app/controllers/case_notes_controller.rb
+++ b/app/controllers/case_notes_controller.rb
@@ -4,4 +4,24 @@ class CaseNotesController < ApplicationController
   def index
     @case_notes = current_user.case_notes.order(created_at: :desc)
   end
+
+  def new
+    @case_note = current_user.case_notes.build
+  end
+
+  def create
+    @case_note = current_user.case_notes.build(case_note_params)
+
+    if @case_note.save
+      redirect_to case_notes_path, notice: "症例メモを作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def case_note_params
+    params.require(:case_note).permit(:body)
+  end
 end

--- a/app/views/case_notes/_form.html.erb
+++ b/app/views/case_notes/_form.html.erb
@@ -1,0 +1,20 @@
+<%= form_with model: case_note do |f| %>
+  <% if case_note.errors.any? %>
+    <div class="alert alert-danger">
+      <ul>
+        <% case_note.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :body, "症例メモ" %><br>
+    <%= f.text_area :body, rows: 8 %>
+  </div>
+
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/case_notes/index.html.erb
+++ b/app/views/case_notes/index.html.erb
@@ -1,3 +1,5 @@
+<p><%= link_to "新規作成", new_case_note_path %></p>
+
 <h1>症例メモ一覧</h1>
 
 <% if @case_notes.any? %>

--- a/app/views/case_notes/new.html.erb
+++ b/app/views/case_notes/new.html.erb
@@ -1,0 +1,5 @@
+<h1>症例メモ作成</h1>
+
+<%= render "form", case_note: @case_note %>
+
+<p><%= link_to "一覧に戻る", case_notes_path %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
   resources :search_sessions, only: %i[index show]
 
   # ====== case note ======
-  resources :case_notes, only: [ :index ]
+  resources :case_notes, only: [ :index, :new, :create ]
 
   # ====== Auth (OAuth / OmniAuth) ======
   get "/auth/:provider/callback", to: "oauths#create"


### PR DESCRIPTION
## 概要
症例メモ（CaseNote）の新規作成機能（new/create）を追加しました。
作成時は current_user に紐づけて保存します。

## 変更点
- case_notes に new/create ルートを追加
- CaseNotesController に new/create を実装
- new 画面とフォーム部分テンプレート（_form）を追加
- 作成後は一覧へリダイレクト

## 動作確認
- ログイン状態でメモを作成できる
- 空送信時にバリデーションエラーが表示される

## 関連Issue
Close #170 