### PR TITLE
【Search】症状検索の完全一致条件を緩和して候補が0件になる問題を修正

### DIFF
--- a/app/services/kampo_search_query.rb
+++ b/app/services/kampo_search_query.rb
@@ -39,8 +39,6 @@ class KampoSearchQuery
     scope
       .joins(:symptoms)
       .where(symptoms: { id: symptom_ids })
-      .group("kampos.id")
-      .having("COUNT(DISTINCT symptoms.id) = ?", symptom_ids.size)
   end
 
   def filter_by_keyword(scope)

--- a/app/views/searches/_step2_content.html.erb
+++ b/app/views/searches/_step2_content.html.erb
@@ -66,8 +66,7 @@
       <% if @symptoms.present? %>
         <%= form_with url: results_search_path, method: :get,
           data: {
-            turbo_frame: "search_step_frame",
-            turbo_action: "advance",
+            turbo: false,
             controller: "disable-submit delayed-loading clear-checkboxes",
             "delayed-loading-delay-value": 300,
             "clear-checkboxes-selector-value": 'input[name="symptom_ids[]"]',


### PR DESCRIPTION
### 背景
症状を複数選択した場合、検索結果が0件になるケースが発生していました。
原因を調査したところ、KampoSearchQuery の filter_by_symptoms において以下の条件が設定されていました。
having("COUNT(DISTINCT symptoms.id) = ?", symptom_ids.size)

この条件は「選択した症状をすべて満たす漢方のみを候補にする」という厳しい条件になっており、
実際のデータでは該当する漢方が存在しない場合が多く、検索結果が0件になる原因となっていました。

また、症状一致数によるスコアリングは KampoSearch 側で実装されているため、
候補抽出の段階で完全一致を要求する必要はありませんでした。

### 変更内容
KampoSearchQuery の filter_by_symptoms を修正し、
症状の完全一致条件（HAVING句）を削除しました。

* 修正前
```
scope
  .joins(:symptoms)
  .where(symptoms: { id: symptom_ids })
  .group("kampos.id")
  .having("COUNT(DISTINCT symptoms.id) = ?", symptom_ids.size)
```
* 修正後
```
scope
  .joins(:symptoms)
  .where(symptoms: { id: symptom_ids })
```

### 変更後の挙動
選択した症状の いずれかに一致する漢方を候補として取得
一致数は KampoSearch 側でスコアとして評価
症状一致数が多い漢方ほど上位に表示

### 期待される効果
検索結果が0件になるケースを減らす
症状一致数によるランキングが正しく機能する

### 影響範囲
漢方検索処理 (KampoSearchQuery)
検索結果の候補抽出ロジック