### PR TITLE
【UX改善】症例メモの文言を「漢方メモ」に統一し編集画面UIを調整

### DIFF
--- a/app/controllers/case_notes_controller.rb
+++ b/app/controllers/case_notes_controller.rb
@@ -35,7 +35,7 @@ class CaseNotesController < ApplicationController
 
   def update
     if @case_note.update(case_note_params)
-      redirect_to(safe_return_to || case_notes_path, notice: "症例メモを更新しました")
+      redirect_to(safe_return_to || case_notes_path, notice: "漢方メモを更新しました")
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/kampos_controller.rb
+++ b/app/controllers/kampos_controller.rb
@@ -6,6 +6,8 @@ class KamposController < ApplicationController
     if current_user && params[:search_session_id].present?
       @search_session = current_user.search_sessions.find_by(id: params[:search_session_id])
 
+      @search_case_note = @search_session&.search_case_note
+
       @case_note = current_user.case_notes.find_by(
         kampo_id: @kampo.id,
         search_session_id: @search_session&.id

--- a/app/controllers/search_sessions_controller.rb
+++ b/app/controllers/search_sessions_controller.rb
@@ -3,7 +3,7 @@ class SearchSessionsController < ApplicationController
 
   def index
     @search_sessions = current_user.search_sessions
-                                    .includes(:case_note) # ← 1件ずつ取りに行くのを防ぐ
+                                    .includes(:search_case_note)
                                     .order(created_at: :desc)
                                     .page(params[:page])
                                     .per(25)

--- a/app/models/search_session.rb
+++ b/app/models/search_session.rb
@@ -1,6 +1,12 @@
 class SearchSession < ApplicationRecord
   belongs_to :user
-  has_one :case_note, dependent: :destroy
+
+  has_one :search_case_note,
+          -> { where(kampo_id: nil) },
+          class_name: "CaseNote",
+          dependent: :destroy
+
+  has_many :case_notes, dependent: :destroy
 
   validates :conditions, presence: true
   validates :conditions_hash, presence: true

--- a/app/views/case_notes/_form.html.erb
+++ b/app/views/case_notes/_form.html.erb
@@ -1,7 +1,10 @@
-<%= form_with model: case_note do |f| %>
+<%= form_with model: case_note, class: "space-y-6" do |f| %>
   <% if case_note.errors.any? %>
-    <div class="alert alert-danger">
-      <ul>
+    <div class="rounded-2xl border border-red-200 bg-red-50 px-4 py-4 shadow-sm">
+      <h2 class="text-sm font-semibold text-red-700">
+        入力内容を確認してください
+      </h2>
+      <ul class="mt-2 list-disc space-y-1 pl-5 text-sm text-red-600">
         <% case_note.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
         <% end %>
@@ -14,13 +17,26 @@
   <%= f.hidden_field :kampo_id %>
   <%= f.hidden_field :search_session_id %>
 
-  <div>
-    <%= f.label :body, "症例メモ" %><br>
-    <%= f.text_area :body, rows: 8 %>
+  <div class="space-y-2">
+    <%= f.label :body, "漢方メモ", class: "block text-sm font-semibold text-slate-900" %>
+    <p class="text-sm leading-relaxed text-slate-600">
+      処方の判断理由や患者の状態、次回確認したいことなどを記録できます。
+    </p>
+
+    <%= f.text_area :body,
+          rows: 10,
+          placeholder: "漢方メモを入力してください",
+          class: "block w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-emerald-500 focus:outline-none focus:ring-4 focus:ring-emerald-100" %>
   </div>
 
-  <div>
-    <%= f.submit %>
+  <div class="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <%= link_to "漢方詳細に戻る",
+        (params[:return_to].presence || kampo_path(case_note.kampo, search_session_id: case_note.search_session_id)),
+        class: "inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50" %>
+
+    <%= f.submit(
+          case_note.persisted? ? "更新する" : "登録する",
+          class: "inline-flex items-center justify-center rounded-full bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus:outline-none focus:ring-4 focus:ring-emerald-200"
+        ) %>
   </div>
 <% end %>
-

--- a/app/views/case_notes/edit.html.erb
+++ b/app/views/case_notes/edit.html.erb
@@ -1,5 +1,45 @@
-<h1>症例メモ編集</h1>
+<div class="bg-slate-50 min-h-screen">
+  <div class="mx-auto max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
+    <section class="space-y-6">
+      <header class="space-y-2">
+        <p class="text-sm font-semibold tracking-wide text-emerald-700">
+          KAMPO NOTE
+        </p>
+        <h1 class="text-2xl font-bold tracking-tight text-slate-900 md:text-3xl">
+          漢方メモ編集
+        </h1>
+        <p class="text-sm leading-relaxed text-slate-600 md:text-base">
+          登録済みの漢方メモを更新できます。
+        </p>
+      </header>
 
-<%= render "form", case_note: @case_note %>
+      <section class="rounded-2xl border border-emerald-200 bg-emerald-50/70 px-5 py-4 shadow-sm">
+        <div class="grid gap-4 sm:grid-cols-2">
+          <div class="rounded-xl bg-white/70 px-4 py-3">
+            <p class="text-xs font-semibold tracking-wide text-emerald-700">
+              対象の漢方
+            </p>
+            <p class="mt-1 text-base font-bold text-slate-900">
+              <%= @case_note.kampo.name %>
+            </p>
+          </div>
 
-<p><%= link_to "一覧に戻る", case_notes_path %></p>
+          <% if @case_note.search_session.present? %>
+            <div class="rounded-xl bg-white/70 px-4 py-3">
+              <p class="text-xs font-semibold tracking-wide text-emerald-700">
+                検索履歴
+              </p>
+              <p class="mt-1 text-sm text-slate-700">
+                <%= @case_note.search_session.created_at.strftime("%Y/%m/%d %H:%M") %> の検索結果
+              </p>
+            </div>
+          <% end %>
+        </div>
+      </section>
+
+      <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <%= render "form", case_note: @case_note %>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/case_notes/new.html.erb
+++ b/app/views/case_notes/new.html.erb
@@ -1,5 +1,21 @@
-<h1>症例メモ作成</h1>
+<div class="bg-slate-50 min-h-screen">
+  <div class="mx-auto max-w-4xl px-4 py-10 sm:px-6 lg:px-8">
+    <section class="space-y-6">
+      <header class="space-y-2">
+        <p class="text-sm font-semibold tracking-wide text-emerald-700">
+          CASE NOTE
+        </p>
+        <h1 class="text-2xl font-bold tracking-tight text-slate-900 md:text-3xl">
+          症例メモ作成
+        </h1>
+        <p class="text-sm leading-relaxed text-slate-600 md:text-base">
+          この検索結果に対する気づきや判断理由を保存できます。
+        </p>
+      </header>
 
-<%= render "form", case_note: @case_note %>
-
-<p><%= link_to "一覧に戻る", case_notes_path %></p>
+      <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <%= render "form", case_note: @case_note %>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/kampos/show.html.erb
+++ b/app/views/kampos/show.html.erb
@@ -7,8 +7,13 @@
           kampo: @kampo,
           favorited: @favorited %>
 
+    <%= render "kampos/show/section_search_note",
+          search_session: @search_session,
+          search_case_note: @search_case_note %>
+
     <%= render "kampos/show/section_note", kampo: @kampo %>
     <%= render "kampos/show/section_detail", kampo: @kampo %>
+
     <%= render "kampos/show/section_case_note",
           kampo: @kampo,
           case_note: @case_note %>

--- a/app/views/kampos/show/_section_case_note.html.erb
+++ b/app/views/kampos/show/_section_case_note.html.erb
@@ -1,45 +1,47 @@
 <section class="space-y-3">
   <h2 class="text-sm font-semibold text-slate-900">
-    この検索結果での自分のメモ
+    この漢方へのメモ
   </h2>
+  <p class="text-sm text-slate-600">
+    この漢方に対する自分用メモです。
+  </p>
 
   <% if current_user && params[:search_session_id].present? %>
-
     <% if case_note.present? %>
-      <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-5 sm:p-6">
-        <div class="text-sm sm:text-base text-slate-700 leading-relaxed break-words">
+      <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+        <div class="text-sm leading-relaxed break-words text-slate-700 sm:text-base">
           <%= simple_format(h(case_note.body)) %>
         </div>
 
-        <div class="mt-4 flex flex-col sm:flex-row gap-3">
+        <div class="mt-4 flex flex-col gap-3 sm:flex-row">
           <%= link_to "メモを編集",
-              edit_case_note_path(case_note),
-              class: "w-full sm:w-auto inline-flex items-center justify-center rounded-xl
-                      border border-slate-300 bg-white
-                      px-6 py-3 text-sm font-semibold text-slate-700
-                      hover:bg-slate-50 transition" %>
+              edit_case_note_path(case_note, return_to: request.fullpath),
+              class: "inline-flex w-full items-center justify-center rounded-xl
+                      border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700
+                      transition hover:bg-slate-50 sm:w-auto" %>
         </div>
       </div>
-
     <% else %>
       <p class="text-sm text-slate-600">
-        この検索結果でのメモはまだありません。
+        この漢方に対するメモはまだありません。
       </p>
 
       <div class="mt-3">
         <%= link_to "メモを書く",
-            new_case_note_path(kampo_id: kampo.id, search_session_id: params[:search_session_id]),
-            class: "w-full sm:w-auto inline-flex items-center justify-center rounded-xl
+            new_case_note_path(
+              kampo_id: kampo.id,
+              search_session_id: params[:search_session_id],
+              return_to: request.fullpath
+            ),
+            class: "inline-flex w-full items-center justify-center rounded-xl
                     bg-emerald-700 px-6 py-3 text-sm font-bold text-white
-                    hover:bg-emerald-800 transition" %>
+                    transition hover:bg-emerald-800 sm:w-auto" %>
       </div>
     <% end %>
-
   <% elsif current_user %>
     <p class="text-sm text-slate-600">
       検索結果から詳細を開いた場合に、この漢方へのメモを表示できます。
     </p>
-
   <% else %>
     <p class="text-sm text-slate-600">
       メモを見るには

--- a/app/views/kampos/show/_section_search_note.html.erb
+++ b/app/views/kampos/show/_section_search_note.html.erb
@@ -1,0 +1,26 @@
+<% if search_session.present? %>
+  <section class="space-y-3">
+    <h2 class="text-sm font-semibold text-slate-900">
+      この検索のメモ
+    </h2>
+    <p class="text-sm text-slate-600">
+      検索条件全体に対して保存したメモです。
+    </p>
+
+    <% if search_case_note&.body.present? %>
+      <div class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+        <div class="text-sm leading-relaxed break-words text-slate-700 sm:text-base">
+          <%= simple_format(h(search_case_note.body)) %>
+        </div>
+
+        <p class="mt-4 text-xs text-slate-500">
+          最終更新：<%= l(search_case_note.updated_at, format: :short) %>
+        </p>
+      </div>
+    <% else %>
+      <p class="text-sm text-slate-600">
+        この検索条件にはまだメモがありません。
+      </p>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/search_sessions/index.html.erb
+++ b/app/views/search_sessions/index.html.erb
@@ -58,7 +58,7 @@
                 <div class="shrink-0 sm:w-36">
                   <div class="w-full inline-flex flex-col items-center justify-center rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm text-center">
                     <span class="font-semibold text-slate-700">検索メモ</span>
-                    <% memo = ss.case_note&.body %>
+                    <% memo = ss.search_case_note&.body %>
                     <span class="text-slate-600"><%= memo.presence || "なし" %></span>
                   </div>
                 </div>

--- a/app/views/search_sessions/show.html.erb
+++ b/app/views/search_sessions/show.html.erb
@@ -119,9 +119,11 @@
                         <%= link_to result.kampo.name,
                             kampo_path(
                               result.kampo,
+                              search_session_id: @search_session.id,
                               medical_area_ids: @search_session.conditions["medical_area_ids"],
                               disease_ids:      @search_session.conditions["disease_ids"],
-                              symptom_ids:      @search_session.conditions["symptom_ids"]
+                              symptom_ids:      @search_session.conditions["symptom_ids"],
+                              return_to:        request.fullpath
                             ),
                             class: "hover:underline" %>
                       </h4>
@@ -141,9 +143,11 @@
                         <%= link_to "詳細 →",
                               kampo_path(
                                 result.kampo,
+                                search_session_id: @search_session.id,
                                 medical_area_ids: @search_session.conditions["medical_area_ids"],
                                 disease_ids:      @search_session.conditions["disease_ids"],
-                                symptom_ids:      @search_session.conditions["symptom_ids"]
+                                symptom_ids:      @search_session.conditions["symptom_ids"],
+                                return_to:        request.fullpath
                               ),
                               class: "inline-flex items-center justify-center rounded-xl
                                       border border-slate-300 bg-white

--- a/app/views/searches/_results_content.html.erb
+++ b/app/views/searches/_results_content.html.erb
@@ -275,7 +275,17 @@
                 </div>
 
                 <h3 class="mt-3 text-2xl md:text-3xl font-extrabold text-slate-900">
-                  <%= link_to top.kampo.name, kampo_path(top.kampo), class: "hover:underline" %>
+                  <%= link_to top.kampo.name,
+                      kampo_path(
+                        top.kampo,
+                        search_session_id: @search_session&.id,
+                        medical_area_ids: params[:medical_area_ids],
+                        disease_ids:      params[:disease_ids],
+                        symptom_ids:      params[:symptom_ids],
+                        return_to:        request.fullpath
+                      ),
+                      data: { turbo_frame: "_top" },
+                      class: "hover:underline" %>
                 </h3>
 
                 <% if top.kampo.note.present? %>


### PR DESCRIPTION
## 概要
メモ機能の文言を「症例メモ」から「漢方メモ」に統一し、
編集画面のUIを調整しました。

## 変更内容
- 「症例メモ」の表記を「漢方メモ」に変更
- メモ編集画面の説明文を調整
- 対象の漢方・検索履歴の情報カードのUIを整理
- メモ入力欄のラベル・プレースホルダを調整

## 目的
ユーザーが「検索メモ」と「漢方メモ」を区別しやすくするため、
文言をアプリの役割に合わせて整理しました。
また、編集画面の情報表示を改善し視認性を向上させました。

## 確認方法
1. 漢方詳細ページから「メモを書く / 編集」をクリック
2. 漢方メモ編集画面が表示されること
3. 文言が「漢方メモ」に統一されていること
4. メモ更新後のフラッシュメッセージが「漢方メモを更新しました」になっていること
